### PR TITLE
Added require for erb.

### DIFF
--- a/lib/yml_reader.rb
+++ b/lib/yml_reader.rb
@@ -1,5 +1,6 @@
 require "yml_reader/version"
 require 'yaml'
+require 'erb'
 
 module YmlReader
 


### PR DESCRIPTION
ERB is required by rspec, but when using yaml reader by itself this results in a uninitialized constant exception. (YmlReader::Erb). If i need to elaborate just let me know. 
