### PR TITLE
Add an include_yml keyword for ERB to pick up

### DIFF
--- a/lib/yml_reader.rb
+++ b/lib/yml_reader.rb
@@ -25,7 +25,11 @@ module YmlReader
   # directory specified by a call to the yml_directory= method.
   #
   def load(filename)
-    @yml = ::YAML.load(ERB.new(File.read("#{yml_directory}/#{filename}")).result)
+    @yml = ::YAML.load(ERB.new(File.read("#{yml_directory}/#{filename}")).result(binding))
   end
-  
+
+  def include_yml(filename)
+    ERB.new(IO.read("#{yml_directory}/#{filename}")).result
+  end
+
 end

--- a/spec/yml_reader/data/include1.yml
+++ b/spec/yml_reader/data/include1.yml
@@ -1,0 +1,2 @@
+'include_1':
+  'key_1': 'Value 1'

--- a/spec/yml_reader/data/with_includes.yml
+++ b/spec/yml_reader/data/with_includes.yml
@@ -1,0 +1,4 @@
+---
+<%= include_yml("include1.yml") %>
+'section_1':
+  'foo': 'bar'

--- a/spec/yml_reader/yml_reader_spec.rb
+++ b/spec/yml_reader/yml_reader_spec.rb
@@ -4,6 +4,9 @@ require 'yaml'
 module MyModule
   extend YmlReader
 
+  def self.data
+    @yml
+  end
   def self.default_directory
     'default_directory'
   end
@@ -22,6 +25,17 @@ describe YmlReader do
 
     it "should default to a directory specified by the containing class" do
       MyModule.yml_directory.should == 'default_directory'
+    end
+  end
+
+  context 'when including files' do
+    before(:each) do
+      MyModule.yml_directory = File.expand_path('data', File.dirname(__FILE__))
+    end
+
+    it 'should load data from included yaml' do
+      MyModule.load 'with_includes.yml'
+      MyModule.data['include_1']['key_1'].should == 'Value 1'
     end
   end
 


### PR DESCRIPTION
This PR adds an include_yml function to be used from within your yaml files.  This allows you to DRY up your test fixtures.

Example using an include in a yaml
```yaml
---
<%= include_yml("include1.yml") %>
'section_1':
  'foo': 'bar'
```

And in include1.yml:
```yaml
'my_key':
  'key_1': 'Value 1'
```
