### PR TITLE
Improved way to include yml files 

### DIFF
--- a/spec/yml_reader/data/include1.yml
+++ b/spec/yml_reader/data/include1.yml
@@ -1,2 +1,3 @@
-'include_1':
-  'key_1': 'Value 1'
+<%= include_yml("include_chain1.yml") %>
+'include1':
+  'keyn1': 'Value 1'

--- a/spec/yml_reader/data/include_chain1.yml
+++ b/spec/yml_reader/data/include_chain1.yml
@@ -1,0 +1,2 @@
+'include_chain1':
+  'key_chain_1': 'chain 1'

--- a/spec/yml_reader/data/nested_include.yml
+++ b/spec/yml_reader/data/nested_include.yml
@@ -1,0 +1,5 @@
+_include_: 'second_chain.yml'
+include_nested:
+  keyn_1: 'Value nested 1'
+  nested_key:
+    _include_: 'nested_value.yml'

--- a/spec/yml_reader/data/nested_value.yml
+++ b/spec/yml_reader/data/nested_value.yml
@@ -1,0 +1,2 @@
+nested_value:
+  deep_nested_key: 'deep nested value'

--- a/spec/yml_reader/data/second_chain.yml
+++ b/spec/yml_reader/data/second_chain.yml
@@ -1,0 +1,2 @@
+'second_chain1':
+  'skey_chain_1': 'schain 1'

--- a/spec/yml_reader/data/with_includes.yml
+++ b/spec/yml_reader/data/with_includes.yml
@@ -1,4 +1,6 @@
 ---
 <%= include_yml("include1.yml") %>
-'section_1':
-  'foo': 'bar'
+_include_:
+  - nested_include.yml
+section_1:
+  foo: 'bar'

--- a/spec/yml_reader/yml_reader_spec.rb
+++ b/spec/yml_reader/yml_reader_spec.rb
@@ -7,24 +7,25 @@ module MyModule
   def self.data
     @yml
   end
+
   def self.default_directory
     'default_directory'
   end
 end
 
 describe YmlReader do
-  context "when configuring the yml directory" do
+  context 'when configuring the yml directory' do
     before(:each) do
       MyModule.yml_directory = nil
     end
-    
-    it "should store a yml directory" do
+
+    it 'should store a yml directory' do
       MyModule.yml_directory = 'some_directory'
-      MyModule.yml_directory.should == 'some_directory'
+      expect(MyModule.yml_directory).to eql('some_directory')
     end
 
-    it "should default to a directory specified by the containing class" do
-      MyModule.yml_directory.should == 'default_directory'
+    it 'should default to a directory specified by the containing class' do
+      expect(MyModule.yml_directory).to eql('default_directory')
     end
   end
 
@@ -35,7 +36,28 @@ describe YmlReader do
 
     it 'should load data from included yaml' do
       MyModule.load 'with_includes.yml'
-      MyModule.data['include_1']['key_1'].should == 'Value 1'
+      expect(MyModule.data['include1']['keyn1']).to eql('Value 1')
+    end
+
+    it 'should load data from  chained included yaml' do
+      MyModule.load 'with_includes.yml'
+      expect(MyModule.data['include_chain1']['key_chain_1']).to eql('chain 1')
+    end
+
+    it 'should load data from _include_ yaml' do
+      MyModule.load 'with_includes.yml'
+      expect(MyModule.data['include_nested']['keyn_1']).to eql('Value nested 1')
+    end
+
+    it 'should load data from  chained _include_ yaml' do
+      MyModule.load 'with_includes.yml'
+      expect(MyModule.data['second_chain1']['skey_chain_1']).to eql('schain 1')
+    end
+
+    it 'should load data from  nested _include_ yaml' do
+      MyModule.load 'with_includes.yml'
+      expect(MyModule.data['include_nested']['nested_key']['nested_value']['deep_nested_key']
+      ).to eql('deep nested value')
     end
   end
 


### PR DESCRIPTION
include_yml - adding support for absolute file path 

adding support for "_include_:" key that can load yml in more flexible way, chained/nested 
as: include_yml - not able to load nested files